### PR TITLE
fix: tiktoken 이슈로 crop history 비활성화

### DIFF
--- a/custom_components/openai_conversation_for_rs/prompt_generator.py
+++ b/custom_components/openai_conversation_for_rs/prompt_generator.py
@@ -140,8 +140,8 @@ class GptHaAssistant:
 
         try:
             # _LOGGER.debug("Chat history: %s", chat_history)
-            cropped_chat_history = self.crop_chat_history(chat_history)
-            self.model_input_messages = self.add_instructions(cropped_chat_history)
+            # cropped_chat_history = self.crop_chat_history(chat_history)
+            self.model_input_messages = self.add_instructions(chat_history)
 
             response = await self.openai_client.chat.completions.create(
                 model=self.deployment_name, messages=self.model_input_messages, tools=self.tool_prompts, n=n


### PR DESCRIPTION
- tiktoken에서 토크나이저 모델 가져오지 못하는 이슈 -> 어차피 ChatCache에서 messages개수 20개 제한있기 때문에, 당장 불필요한 crop history 코드 임시 비활성화