### PR TITLE
fix: pydantic v1에서의 model_dump_json 이슈 해결

### DIFF
--- a/custom_components/openai_conversation_for_rs/message_model.py
+++ b/custom_components/openai_conversation_for_rs/message_model.py
@@ -119,7 +119,7 @@ class AssistantMessage(BaseMessage):
                 tool_call_dict = tool_call.model_dump()
 
                 if to_str_arguments:
-                    arguments = tool_call.function.arguments.model_dump_json()
+                    arguments = json.dumps(tool_call.function.arguments.dict())
 
                     tool_call_dict["function"] = {
                         "arguments": arguments,


### PR DESCRIPTION
- pydantic v2에서만 지원하는 model_dump_json() 로직을 v1에서 사용할 수 있도록 수정